### PR TITLE
refactor: Updated the README.md broken link to the Github Audacia.Log #183008

### DIFF
--- a/Audacia.Log/README.md
+++ b/Audacia.Log/README.md
@@ -1,7 +1,7 @@
 ﻿## Audacia.Log
 
 Standardized logging configuration for Audacia projects using [Serilog](https://serilog.net).
-This package should only be added if the application is a legacy, if ASP.NET Core use [Audacia.Log.AspNetCore](https://dev.azure.com/audacia/Audacia/_git/Audacia.Log?path=%2FAudacia.Log.AspNetCore&_a=readme) instead.
+This package should only be added if the application is a legacy, if ASP.NET Core use [Audacia.Log.AspNetCore](https://github.com/audaciaconsulting/Audacia.Log) instead.
 
 ### Usage
 


### PR DESCRIPTION
# Summary

Updated all links referencing the old Audacia.Build DevOps library to point at the Github equivalent